### PR TITLE
Add Dockerfile for x86_64 ubuntu22.04

### DIFF
--- a/Dockerfiles/Dockerfile.x86_64.ubuntu22.04
+++ b/Dockerfiles/Dockerfile.x86_64.ubuntu22.04
@@ -1,0 +1,4 @@
+FROM amd64/ubuntu:22.04
+
+COPY ./run-on-arch-install.sh /root/run-on-arch-install.sh
+RUN chmod +x /root/run-on-arch-install.sh && /root/run-on-arch-install.sh


### PR DESCRIPTION
The Nightly builds of RustDesk are currently failing in the Flatpak jobs with the following error:

```
error: Unable to load summary from remote flathub: URI https://dl.flathub.org/repo/summary exceeded maximum size of 10485760 bytes
```
The failing jobs are based on `distro: ubuntu18.04`, which does not include the following upstream fix:
https://github.com/ostreedev/ostree/commit/4bac96a8c817beda37448f9b8c662162bb619981

This PR introduces an x86_64 Dockerfile based on `ubuntu22.04`, which can be used in `flutter-nightly.yml` to resolve the issue in those jobs.